### PR TITLE
Add browser SQLite persistence

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,8 @@ Aplicación web sencilla para gestionar un portfolio de inversión. Se puede imp
 - Dividendos recibidos.
 - Opciones negociadas.
 
+Los datos importados se almacenan localmente en el navegador mediante una base de datos SQLite gestionada con **sql.js**, por lo que no es necesario volver a cargar los CSV cada vez que se abre la página. El código JavaScript se divide en dos archivos: `db.js` con las funciones de base de datos y `script.js` con el resto de la lógica.
+
 La interfaz está construida con **Tailwind CSS** y muestra:
 
 - Una barra superior con el nombre de la aplicación.

--- a/db.js
+++ b/db.js
@@ -1,0 +1,60 @@
+let SQL, db;
+
+async function initDatabase() {
+  SQL = await initSqlJs({
+    locateFile: file => `https://cdnjs.cloudflare.com/ajax/libs/sql.js/1.8.0/${file}`
+  });
+  const saved = localStorage.getItem('portfolioDb');
+  if (saved) {
+    const bytes = Uint8Array.from(atob(saved), c => c.charCodeAt(0));
+    db = new SQL.Database(bytes);
+  } else {
+    db = new SQL.Database();
+    createTables();
+  }
+}
+
+function createTables() {
+  db.run(`CREATE TABLE IF NOT EXISTS trades(ticker TEXT, quantity REAL, purchase REAL);`);
+  db.run(`CREATE TABLE IF NOT EXISTS transfers(currency TEXT, datetime TEXT, amount REAL);`);
+}
+
+function saveDb() {
+  const data = db.export();
+  const base64 = btoa(String.fromCharCode.apply(null, data));
+  localStorage.setItem('portfolioDb', base64);
+}
+
+function loadTrades() {
+  if (!db) return [];
+  const res = db.exec('SELECT ticker, quantity, purchase FROM trades');
+  if (!res.length) return [];
+  return res[0].values.map(r => ({ Ticker: r[0], Quantity: r[1], PurchasePrice: r[2] }));
+}
+
+function loadTransfers() {
+  if (!db) return [];
+  const res = db.exec('SELECT currency, datetime, amount FROM transfers');
+  if (!res.length) return [];
+  return res[0].values.map(r => ({ CurrencyPrimary: r[0], DateTime: new Date(r[1]), Amount: r[2] }));
+}
+
+function storeTrades(rows) {
+  if (!db) return;
+  db.run('DELETE FROM trades');
+  const stmt = db.prepare('INSERT INTO trades VALUES (?, ?, ?)');
+  rows.forEach(r => stmt.run([r.Ticker, r.Quantity, r.PurchasePrice]));
+  stmt.free();
+  saveDb();
+}
+
+function storeTransfers(rows) {
+  if (!db) return;
+  db.run('DELETE FROM transfers');
+  const stmt = db.prepare('INSERT INTO transfers VALUES (?, ?, ?)');
+  rows.forEach(r => stmt.run([r.CurrencyPrimary, r.DateTime.toISOString(), r.Amount]));
+  stmt.free();
+  saveDb();
+}
+
+window.db = { initDatabase, loadTrades, loadTransfers, storeTrades, storeTransfers };

--- a/index.html
+++ b/index.html
@@ -8,6 +8,8 @@
   <script src="https://cdn.jsdelivr.net/npm/chart.js@4.4.0/dist/chart.umd.min.js"></script>
   <script src="https://cdn.jsdelivr.net/npm/chartjs-adapter-date-fns@3"></script>
   <script src="https://cdn.jsdelivr.net/npm/papaparse@5.3.2/papaparse.min.js"></script>
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/sql.js/1.8.0/sql-wasm.js"></script>
+  <script src="db.js"></script>
 </head>
 <body class="bg-gray-100 min-h-screen">
   <nav class="bg-gray-800 text-white p-4 mb-6">

--- a/script.js
+++ b/script.js
@@ -8,25 +8,38 @@ let trades = [];
 let transfers = [];
 let dividends = [];
 let optionsData = [];
+window.addEventListener('DOMContentLoaded', setup);
+
+async function setup() {
+  await db.initDatabase();
+  trades = db.loadTrades();
+  if (trades.length) {
+    loadPositions();
+  }
+  transfers = db.loadTransfers();
+  if (transfers.length) {
+    drawCashChart(transfers);
+  }
+}
 
 tradesInput.addEventListener('change', event => handleCsv(event, data => {
   trades = sanitizeTrades(data);
+  db.storeTrades(trades);
   loadPositions();
 }));
 
 transfersInput.addEventListener('change', event => handleCsv(event, data => {
   transfers = sanitizeTransfers(data);
+  db.storeTransfers(transfers);
   drawCashChart(transfers);
 }));
 
 dividendsInput.addEventListener('change', event => handleCsv(event, data => {
   dividends = data;
-  console.log('Dividends loaded', dividends);
 }));
 
 optionsInput.addEventListener('change', event => handleCsv(event, data => {
   optionsData = data;
-  console.log('Options loaded', optionsData);
 }));
 
 function handleCsv(event, cb, opts = {}) {
@@ -38,7 +51,6 @@ function handleCsv(event, cb, opts = {}) {
     quote: true,
     complete: function(results) {
       cb(results.data);
-      console.log(results)
     }
   }, opts));
 }
@@ -149,7 +161,6 @@ function drawChart(rows) {
 
 function computeCashHistory(rows) {
   const sorted = [...rows].sort((a, b) => a.DateTime - b.DateTime);
-  console.log(sorted)
   const histories = {};
   sorted.forEach(r => {
     const currency = r.CurrencyPrimary;
@@ -161,7 +172,6 @@ function computeCashHistory(rows) {
       : 0;
     histories[currency].push({ x: date, y: last + amount });
   });
-  console.log(histories)
   return histories;
 }
 


### PR DESCRIPTION
## Summary
- store imported data in a browser SQLite database
- load existing database on page load
- split database logic to new file
- mention persistence and script split in README

## Testing
- `node -v`


------
https://chatgpt.com/codex/tasks/task_e_688691809a348333bae3d09de66fbbb9